### PR TITLE
Nix derivation, devShell, and modules for home-manager and NixOS

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 /target
 /node_modules
+/.direnv
+result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6020,8 +6020,7 @@ dependencies = [
 [[package]]
 name = "libffi-sys"
 version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
+source = "git+https://github.com/tov/libffi-rs?rev=d0704d634b6f3ffef5b6fc7e07fe965a1cff5c7b#d0704d634b6f3ffef5b6fc7e07fe965a1cff5c7b"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,7 @@ gauntlet-cli = { path = "rust/cli" }
 [features]
 release = ["gauntlet-cli/release"]
 scenario_runner = ["gauntlet-cli/scenario_runner"]
+
+[patch.crates-io]
+# NOTE https://github.com/ipetkov/crane/issues/336
+libffi-sys = { git = "https://github.com/tov/libffi-rs", rev = "d0704d634b6f3ffef5b6fc7e07fe965a1cff5c7b" }

--- a/README.md
+++ b/README.md
@@ -185,9 +185,15 @@ To start `systemd` service run:
 systemctl --user enable --now gauntlet.service
 ```
 
+#### Nix
+
+The nix flake in this repository is community maintained. If you face a problem, please create an issue and hopefully somebody will work on it.
+
+To install, you either know what to do, or you can read more [here](nix/README.md).
+
 #### Other Linux Distributions
 
-At the moment application is only available for Arch Linux. If you want to create a package for other distributions see [Application packaging for Linux](#application-packaging-for-Linux)
+At the moment application is only available for Arch Linux and Nix. If you want to create a package for other distributions see [Application packaging for Linux](#application-packaging-for-Linux)
 
 ### Global Shortcut
 Main window can be opened using global shortcut or CLI command:
@@ -367,7 +373,7 @@ This section contains a list of things
 that could be useful for someone who wants to package application for Linux distribution.
 If something is missing, please [create an issue](https://github.com/project-gauntlet/gauntlet/issues).
 
-Application is already packaged for Arch Linux so you can use it as example, see [Arch Linux](#arch-linux)
+Application is already packaged for [Arch Linux](#arch-linux) and [Nix](#nix) so you can use them as examples.
 
 Relevant CLI commands:
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,13 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+    fetchTarball {
+      url =
+        lock.nodes.${nodeName}.locked.url
+        or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+      sha256 = lock.nodes.${nodeName}.locked.narHash;
+    }
+) {src = ./.;})
+.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,107 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1733688869,
+        "narHash": "sha256-KrhxxFj1CjESDrL5+u/zsVH0K+Ik9tvoac/oFPoxSB8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "604637106e420ad99907cae401e13ab6b452e7d9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733392399,
+        "narHash": "sha256-kEsTJTUQfQFIJOcLYFt/RvNxIK653ZkTBIs4DG+cBns=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d0797a04b81caeae77bcff10a9dde78bc17f5661",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1733096140,
+        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "https://github.com/project-gauntlet/gauntlet";
+  outputs = inputs: inputs.flake-parts.lib.mkFlake {inherit inputs;} {imports = [./nix];};
+  inputs = {
+    nixpkgs.url = github:nixos/nixpkgs/nixos-unstable;
+    systems.url = github:nix-systems/default;
+    flake-parts.url = github:hercules-ci/flake-parts;
+    flake-compat.url = github:edolstra/flake-compat;
+    flake-compat.flake = false;
+    crane.url = github:ipetkov/crane;
+  };
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,64 @@
+# Nix
+
+The Nix package derivation is currently defined for all [default systems](https://github.com/nix-systems/default), and it can be integrated into NixOS and Home-Manager configurations as below.
+
+## Installation
+
+Here's how to reference the package derivation (and explicitly pin it) in your `flake.nix`:
+
+``` nix
+{
+  inputs.gauntlet.url = github:project-gauntlet/gauntlet/<gauntlet_version_repository_tag>;
+  inputs.gauntlet.inputs.nixpkgs.follows = "nixpkgs";
+}
+```
+
+The package can then be referenced directly with `gauntlet.packages.${system}.default` or integrated as an overlay with `gauntlet.overlays.default`.
+
+## Configuration
+
+Under `programs.gauntlet`, the options provide the following:
+
+1. `enable`: adds executable to system path
+2. `service.enable`: runs daemon with systemd (MacOS launchd not yet supported)
+
+The examples below assume flake inputs are passed to `nixpkgs.lib.nixosSystem` and `home-manager.lib.mkHomeManagerConfiguration` respectively as `inputs` parameter.
+
+### NixOS
+
+``` nix
+{inputs, ...}: {
+  imports = [inputs.gauntlet.nixosModules.default];
+  programs.gauntlet = {
+    enable = true;
+    service.enable = true;
+  };
+}
+```
+
+### Home-Manager
+
+Once `config.toml` is [supported](../README.md#application-config), Home-Manager can populate its contents with `programs.gauntlet.config`.
+
+``` nix
+{inputs, ...}: {
+  imports = [inputs.gauntlet.homeManagerModules.default];
+  programs.gauntlet = {
+    enable = true;
+    service.enable = true;
+    config = {};
+  };
+}
+```
+
+## Development
+
+When updating dependencies or bumping the project version, please follow these steps to adjust the relevant values at the top of `./nix/overlay.nix`:
+
+1. If there is a new package release, set `version` to that upcoming version tag.
+2. If `package-lock.json` has changed, set `npmDepsHash` to `""` and rebuild with `nix build`, copying the actual value back into `npmDepsHash`. This is necessary for `fetchNpmDeps` because `importNpmLock` doesn't work with `git://` dependencies like for `@project-gauntlet/tools`.
+3. If `Cargo.lock` has changed, run `nix run .#fetch-rusty-v8-hashes` and replace `RUSTY_V8_ARCHIVE` as instructed if different. Because building `librusty_v8` takes forever, we follow nixpkgs precedent and fetch binaries in a fixed-output-derivation.
+
+When making any changes to nix code, please format with `nix fmt` when done.
+
+When running the project in development, `.#devShells.default` will provide access to all repository tooling. You can access this by running `nix develop`, or `direnv allow` if you have `direnv` + `nix-direnv`.

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,31 @@
+{inputs, ...}: {
+  imports = [
+    ./modules/home.nix
+    ./modules/nixos.nix
+    ./overlay.nix
+  ];
+  systems = import inputs.systems;
+  perSystem = {
+    pkgs,
+    lib,
+    system,
+    ...
+  }: let
+    inherit (pkgs) alejandra cargo cmake deno gauntlet gtk3 libxkbcommon libGL mkShell nodejs protobuf stdenv xorg wayland;
+  in {
+    _module.args.pkgs = import inputs.nixpkgs {
+      inherit system;
+      overlays = [inputs.self.overlays.default];
+    };
+    devShells.default = mkShell {
+      packages = [cargo cmake deno nodejs protobuf];
+      shellHook = lib.optionalString stdenv.hostPlatform.isLinux ''
+        export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${lib.makeLibraryPath [libxkbcommon libGL xorg.libX11 wayland]}"
+        export PATH="$PATH:${lib.makeBinPath [gtk3]}"
+      '';
+    };
+    formatter = alejandra;
+    packages.default = gauntlet;
+    packages.fetch-rusty-v8-hashes = gauntlet.fetchRustyV8Hashes;
+  };
+}

--- a/nix/modules/common.nix
+++ b/nix/modules/common.nix
@@ -1,0 +1,12 @@
+{self, ...}: {
+  lib,
+  pkgs,
+  ...
+}: {
+  options.programs.gauntlet = {
+    enable = lib.mkEnableOption "Gauntlet application launcher";
+    package = lib.mkPackageOption pkgs "gauntlet" {};
+    service.enable = lib.mkEnableOption "running Gauntlet as a service";
+  };
+  config.nixpkgs.overlays = [self.overlays.default];
+}

--- a/nix/modules/home.nix
+++ b/nix/modules/home.nix
@@ -1,0 +1,35 @@
+flake: {
+  flake.homeManagerModules.default = {
+    config,
+    lib,
+    pkgs,
+    ...
+  }: let
+    inherit (lib) elem getExe mkIf mkMerge mkOption platforms toList types;
+    inherit (pkgs.stdenv.hostPlatform) isLinux isDarwin;
+    cfg = config.programs.gauntlet;
+    toml = pkgs.formats.toml {};
+  in {
+    imports = [(import ./common.nix flake)];
+    options.programs.gauntlet.config = mkOption {
+      inherit (toml) type;
+      default = {};
+      description = "Application configuration in config.toml";
+    };
+    config = mkIf cfg.enable {
+      home.packages = [cfg.package];
+      launchd.agents = mkIf (cfg.service.enable && isDarwin) {
+        gauntlet.enable = true;
+        gauntlet.config = {
+          RunAtLoad = true;
+          KeepAlive.Crashed = true;
+          ProgramArguments = [(getExe cfg.package) "--minimized"];
+        };
+      };
+      xdg.configFile = mkMerge [
+        (mkIf (cfg.service.enable && isLinux) {"systemd/user/gauntlet.service".source = "${cfg.package}/lib/systemd/user/gauntlet.service";})
+        (mkIf (cfg.config != {}) {"gauntlet/config.toml".source = toml.generate "gauntlet.config.toml" config.programs.gauntlet.config;})
+      ];
+    };
+  };
+}

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -1,0 +1,15 @@
+flake: {
+  flake.nixosModules.default = {
+    config,
+    lib,
+    ...
+  }: let
+    cfg = config.programs.gauntlet;
+  in {
+    imports = [(import ./common.nix flake)];
+    config = lib.mkIf cfg.enable {
+      environment.systemPackages = [cfg.package];
+      systemd.packages = lib.mkIf cfg.service.enable [cfg.package];
+    };
+  };
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,119 @@
+{
+  config,
+  inputs,
+  ...
+}: {
+  flake.overlays.default = final: _: let
+    # These must be updated following the instructions in ./nix/README.md when dependencies are updated or the version bumped
+    version = "v11";
+    npmDepsHash = "sha256-zcqn+EsxWfdxkIKUnF8kiuURtPiE6XQOaDAspuKEe64=";
+    RUSTY_V8_ARCHIVE = fetchRustyV8 "130.0.2" {
+      aarch64-darwin = "sha256-aWZ/4Q4Wttx37xOdBmTCPGP+eYGhr4CM1UkYq8pC7Qs=";
+      aarch64-linux = "sha256-p9+tHmKIM5wBABubHIAstpwfzO19ypPzOuaV4b6loCU=";
+      x86_64-darwin = "sha256-zNC0DAkMbbFM1M+t6rgKtN0QAm4ONEbCi6Sxivhf8dk=";
+      x86_64-linux = "sha256-ew2WZhdsHfffRQtif076AWAlFohwPo/RbmW/6D3LzkU=";
+    };
+
+    inherit
+      (final)
+      # Libraries
+      lib
+      stdenv
+      # Builders
+      buildPackages
+      fetchurl
+      fetchNpmDeps
+      makeWrapper
+      writeShellScriptBin
+      # Packages
+      cmake
+      deno
+      gtk3
+      libxkbcommon
+      libGL
+      xorg
+      nodejs
+      openssl
+      pkg-config
+      protobuf
+      wayland
+      yq
+      ;
+    inherit (buildPackages.npmHooks.override {inherit nodejs;}) npmConfigHook;
+    inherit (lib) concatStringsSep getExe' makeBinPath makeLibraryPath optional;
+    inherit (stdenv.hostPlatform) isLinux rust system;
+    # Borrowed from other packages in nixpkgs https://github.com/search?q=repo%3ANixOS%2Fnixpkgs%20RUSTY_V8_ARCHIVE&type=code
+    buildRustyV8Url = version: target: "https://github.com/denoland/rusty_v8/releases/download/v${version}/librusty_v8_release_${target}.a.gz";
+    fetchRustyV8 = version: hashes:
+      fetchurl {
+        name = "librusty_v8-${version}";
+        url = buildRustyV8Url version rust.rustcTarget;
+        hash = hashes.${system};
+        meta.version = version;
+        meta.sourceProvenance = [lib.sourceTypes.binaryNativeCode];
+      };
+    fetchRustyV8Hashes = writeShellScriptBin "fetch-librusty_v8-hashes.sh" ''
+      version=$(${getExe' yq "tomlq"} '.package | map(select(.name == "v8")) | .[0].version' --raw-output ${inputs.self}/Cargo.lock)
+      echo "Update ./nix/overlay.nix as follows:"
+      echo "RUSTY_V8_ARCHIVE = fetchRustyV8 \"$version\" {"
+      for system in ${concatStringsSep " " config.systems}; do
+          target=$(nix eval --raw nixpkgs#legacyPackages.$system.stdenv.hostPlatform.rust.rustcTarget)
+          hash=$(nix-prefetch-url --print-path ${buildRustyV8Url "$version" "$target"} | tail -n 1 | xargs nix hash file)
+          echo "  $system = \"$hash\";"
+      done
+      echo "};"
+    '';
+    pname = "gauntlet";
+    src = inputs.self;
+    cargoArtifactsArgs = {
+      inherit pname src version RUSTY_V8_ARCHIVE;
+      cargoExtraArgs = "--features release";
+      nativeBuildInputs = [cmake pkg-config protobuf];
+      buildInputs = [openssl];
+      # OPENSSL_CONFIG_DIR didn't work for vendored dependencies
+      OPENSSL_NO_VENDOR = true;
+    };
+    craneLib = inputs.crane.mkLib final;
+    cargoArtifacts = craneLib.buildDepsOnly cargoArtifactsArgs;
+  in {
+    gauntlet = craneLib.buildPackage {
+      inherit (cargoArtifactsArgs) cargoExtraArgs OPENSSL_NO_VENDOR RUSTY_V8_ARCHIVE;
+      inherit cargoArtifacts pname src version;
+      # fetchNpmDeps + makeCacheWritable is necessary with npm git:// dependencies
+      npmDeps = fetchNpmDeps {
+        inherit src;
+        name = "${pname}-${version}-npm-deps";
+        hash = npmDepsHash;
+      };
+      makeCacheWritable = true;
+      nativeBuildInputs = cargoArtifactsArgs.nativeBuildInputs ++ [nodejs npmConfigHook] ++ optional isLinux makeWrapper;
+      buildInputs = cargoArtifactsArgs.buildInputs ++ [deno];
+      preBuild = "npm run build";
+      postInstall =
+        if isLinux
+        then ''
+          install -Dm644 assets/linux/gauntlet.desktop $out/share/applications/gauntlet.desktop
+          install -Dm644 assets/linux/gauntlet.service $out/lib/systemd/user/gauntlet.service
+          install -Dm644 assets/linux/icon_256.png $out/share/icons/hicolor/256x256/apps/gauntlet.png
+        ''
+        else ''
+          contentsDir=$out/Applications/Gauntlet.app/Contents
+          install -Dm755 $out/bin/gauntlet $contentsDir/MacOS/Gauntlet
+          install -Dm644 assets/macos/AppIcon.icns $contentsDir/Resources/AppIcon.icns
+          install -Dm644 assets/macos/Info.plist $contentsDir/Info.plist
+        '';
+      postFixup =
+        if isLinux
+        then ''
+          patchelf --add-rpath ${makeLibraryPath [libxkbcommon libGL xorg.libX11 wayland]} $out/bin/gauntlet
+          wrapProgram $out/bin/gauntlet --suffix PATH : ${makeBinPath [gtk3]}
+          substituteInPlace $out/lib/systemd/user/gauntlet.service --replace /usr/bin/gauntlet $out/bin/gauntlet
+        ''
+        else ''
+          substituteInPlace $out/Applications/Gauntlet.app/Contents/Info.plist --replace __VERSION__ ${version}
+        '';
+      passthru = {inherit fetchRustyV8Hashes;};
+      meta.mainProgram = "gauntlet";
+    };
+  };
+}


### PR DESCRIPTION
~~This is still a WIP, but I wanted to at least share a draft so people know it's being worked on. As of writing this, the package runs as expected on aarch64-darwin. The package builds on x86_64-linux, but my device is Wayland and I'm having trouble exposing the runtime Wayland libraries. I have not tested on other platforms or non-Wayland x86_64-linux yet. I am still missing part of the project's packaging script that exposes the icons, service unit files, and more. The modules are ready to go though for when these are properly exposed and gauntlet file configuration is released.~~

This was somewhat tough to package for a few reasons which are explained in ./nix/pkgs/overlay.nix. Nix has a build sandbox that prevents network access during the build phase, so because the project uses submodules and network calls during build time, I had to apply various patches. I think ideally it wouldn't look like this because they unfortunately conflict with Nix philosophy, for good reason I would argue, but this is the current state of the project and it looks as if these challenges were recent design choices. Happy to explain or resolve anything as I continue and you review.

EDIT: Runs on x86_64-linux (X11 and Wayland), aarch64-darwin, aarch-64-linux (X11 and Wayland), both as a service and standalone with assets propagated. Crane is in use to build with dependency caching to avoid expensive rebuilds. `fetch-rusty-v8-hashes` script provided to get binding hashes for updated versions.