### PR TITLE
fix: libxkbcommon + pkg-config for linux devshell

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -11,17 +11,19 @@
     system,
     ...
   }: let
-    inherit (pkgs) alejandra cargo cmake deno gauntlet gtk3 libxkbcommon libGL mkShell nodejs protobuf stdenv xorg wayland;
+    inherit (lib) makeBinPath makeLibraryPath optionals optionalString;
+    inherit (pkgs) alejandra cargo cmake deno gauntlet gtk3 libxkbcommon libGL mkShell nodejs pkg-config protobuf stdenv xorg wayland;
+    inherit (stdenv.hostPlatform) isLinux;
   in {
     _module.args.pkgs = import inputs.nixpkgs {
       inherit system;
       overlays = [inputs.self.overlays.default];
     };
     devShells.default = mkShell {
-      packages = [cargo cmake deno nodejs protobuf];
-      shellHook = lib.optionalString stdenv.hostPlatform.isLinux ''
-        export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${lib.makeLibraryPath [libxkbcommon libGL xorg.libX11 wayland]}"
-        export PATH="$PATH:${lib.makeBinPath [gtk3]}"
+      packages = [cargo cmake deno nodejs protobuf] ++ optionals isLinux [libxkbcommon pkg-config];
+      shellHook = optionalString isLinux ''
+        export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${makeLibraryPath [libGL xorg.libX11 wayland]}"
+        export PATH="$PATH:${makeBinPath [gtk3]}"
       '';
     };
     formatter = alejandra;


### PR DESCRIPTION
Because libxkbcommon is needed during package build now on Linux, we have to included it as a package and configure it for access by smithay-client-toolkit with pkg-config.