### PR TITLE
Reduce release binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,11 @@ gauntlet-cli = { path = "rust/cli" }
 release = ["gauntlet-cli/release"]
 scenario_runner = ["gauntlet-cli/scenario_runner"]
 
+[profile.release]
+opt-level = "s"
+lto = true
+strip = true
+
 [patch.crates-io]
 # NOTE https://github.com/ipetkov/crane/issues/336
 libffi-sys = { git = "https://github.com/tov/libffi-rs", rev = "d0704d634b6f3ffef5b6fc7e07fe965a1cff5c7b" }


### PR DESCRIPTION
`strip = true` alone reduces the size by 40MB!

I have unfortunately not been able to measure the effect of the other settings, but in my experience they reduce the size drastically on projects that have a lot of dependencies (like this one).

*LTO (Link-Time optimizations):* This should help out trim code from dependencies that is not used, that can be detected at link time, which I believe there is a lot of. Note: Depending on the project, this might add a substantial amount of time to the release builds, but I have not been able to test it at the time of writing. Any help to get that working to measure the time vs size gains is welcome :)
*Optimize for size:* As the option implies, it will optimize the binary for size rather than for speed. It is the equivalent of `-02` with some more precautions to make the binary smaller. In rustc 1.18.0+, using `opt-level = s` is a combination of LLVM flags, setting speed optimization to 2 (ending in the same optimizations as opt-level = 2) and size optimization to 1 (2 being aggressive). I generally prefer this than `'z'` as it can actually degrade performance.

Further paths to reduce the size of the binary would be to trim down those dependencies and cleanup the code with a tool like [`cargo-bloat`](https://github.com/RazrFalcon/cargo-bloat).

Relates to #6 