### PR TITLE
plugins/gauntlet: applications/macos: follow symlinks inside /Applications

### DIFF
--- a/bundled_plugins/gauntlet/src/applications.tsx
+++ b/bundled_plugins/gauntlet/src/applications.tsx
@@ -196,7 +196,7 @@ export default async function Applications(context: GeneratorContext<object, Ent
                 }),
                 add,
                 remove,
-                { exts: ["app"], maxDepth: 2 }
+                { exts: ["app"], maxDepth: 2, followSymlinks: true, }
             );
         }
         case "windows": {


### PR DESCRIPTION
Symlinks are not followed by default in function `walk` in the package deno @std/fs

Use case: I use nix on my Mac to install some applications (for example `JOSM`).

<img width="862" alt="Screenshot 2025-06-12 at 00 31 07" src="https://github.com/user-attachments/assets/daa43205-c0fd-46e1-ab90-0a6c9e33231e" />


JOSM is not picked up by the `Applications` plugin in Gauntlet, because it dooes not reside in `/Applications`, but in `/Applications/Nix Apps` which is a symlink to the nix store:

```shell
$ tree -L 1 "/Applications" | rg JOSM
$ tree -L 1 "/Applications/Nix Apps" | rg JOSM
├── JOSM.app -> /nix/store/y3zsbx43x9s0s0pyr76kzy5m7q9d6izp-josm-19396/Applications/JOSM.app
```

After this patch, the `Applications` plugin picks up JOSM: 
<img width="862" alt="Screenshot 2025-06-12 at 00 29 47" src="https://github.com/user-attachments/assets/ffb3219f-c5da-405e-a734-669dd784b9b5" />

Reference: https://jsr.io/@std/fs@1.0.18/doc/~/WalkOptions
