### PR TITLE
GitHub Actions: formatting: Nix with Alejandra

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.yaml]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,12 +1,19 @@
 name: format
 on: [push, pull_request]
 jobs:
-  all:
+  rust:
     runs-on: ubuntu-latest
     steps:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
       - uses: actions/checkout@v4
-      - name: Check format
-        run: cargo +nightly fmt --all -- --check --verbose
+      - name: rustfmt
+        run: cargo +nightly fmt --all -- --check
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cachix/install-nix-action@v31
+      - uses: actions/checkout@v4
+      - name: alejandra
+        run: nix shell nixpkgs#alejandra -c alejandra -c .


### PR DESCRIPTION
- Checking nix formatting with Alejandra, as described in nix files
- Removed `--verbose` in `rustfmt`, it logs even when everything is well formatted (can cause some confusion)
- Added editorconfig.org for cross-editor configs, for yaml files