### PR TITLE
fix: nix build

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -6,12 +6,12 @@
   flake.overlays.default = final: _: let
     version = "v${builtins.readFile ./../VERSION}";
     # These must be updated following the instructions in ./nix/README.md when dependencies are updated or the version bumped
-    npmDepsHash = "sha256-AAnbT3B68U+dTqTfCA4eYFo+VQBcY4LTj98Nnq+sIes=";
-    RUSTY_V8_ARCHIVE = fetchRustyV8 "130.0.2" {
-      aarch64-darwin = "sha256-aWZ/4Q4Wttx37xOdBmTCPGP+eYGhr4CM1UkYq8pC7Qs=";
-      aarch64-linux = "sha256-p9+tHmKIM5wBABubHIAstpwfzO19ypPzOuaV4b6loCU=";
-      x86_64-darwin = "sha256-zNC0DAkMbbFM1M+t6rgKtN0QAm4ONEbCi6Sxivhf8dk=";
-      x86_64-linux = "sha256-ew2WZhdsHfffRQtif076AWAlFohwPo/RbmW/6D3LzkU=";
+    npmDepsHash = "sha256-CrQeEFpyKiYOTuNg6lZz7HwF1EEM4zV2iXse5UcKSFY=";
+    RUSTY_V8_ARCHIVE = fetchRustyV8 "137.2.0" {
+      aarch64-darwin = "sha256-fgmFCBPeD7u9qXcVjgCO1oTr1mXLrtvqy4rMftZO0iE=";
+      aarch64-linux = "sha256-0+2QcsjAx80Ethrulnp0nDQRphkuaDfuaW5GkIxWmb8=";
+      x86_64-darwin = "sha256-p+B1tpPImRJt9R+TJpuUhiX7Q8dh7emf/Hca8K18Zh8=";
+      x86_64-linux = "sha256-9M67FZ4TzjoiGL73B8Jtwn38lW521yCLIqyvGzYCc50=";
     };
 
     inherit


### PR DESCRIPTION
Fixes #73

Following the instructions in `nix/README.md`, we need to update the `npmDepsHash` and `RUSTY_V8_ARCHIVE` values, since it seems like the values in `package-lock.json` and `Cargo.lock` have changed.

I'm still unable to build `gauntlet` in my machine with this, but now the error seems to happen in the Rust side, and I don't have enough context to figure it out.

```
       >     Checking triomphe v0.1.14
       >    Compiling zvariant_utils v3.2.0
       >     Checking capacity_builder v0.5.0
       >     Checking tokio-stream v0.1.17
       >     Checking h2 v0.4.10
       >     Checking hstr v1.1.0
       >     Checking tower v0.5.2
       > error: `core::slice::<impl [T]>::copy_from_slice` is not yet stable as a const fn
       >    --> /nix/store/22fdqk8l8hgsj5mmc4kgsx1m7hy7w6lv-vendor-cargo-deps/c19b7c6f923b580ac259164a89f2577984ad5ab09ee9d583b888f934adbbe8d0/hstr-1.1.0/src/dynamic.rs:161:13
       >     |
       > 161 | /             unsafe_data
       > 162 | |                 .data_mut()
       > 163 | |                 .split_at_mut(len)
       > 164 | |                 .0
       > 165 | |                 .copy_from_slice(text.as_bytes());
       >     | |_________________________________________________^
       >     |
       > help: add `#![feature(const_copy_from_slice)]` to the crate attributes to enable
       >    --> /nix/store/22fdqk8l8hgsj5mmc4kgsx1m7hy7w6lv-vendor-cargo-deps/c19b7c6f923b580ac259164a89f2577984ad5ab09ee9d583b888f934adbbe8d0/hstr-1.1.0/src/lib.rs:4:1
       >     |
       > 4   + #![feature(const_copy_from_slice)]
       >     |
       >
       > error: could not compile `hstr` (lib) due to 1 previous error
       > warning: build failed, waiting for other jobs to finish...
```